### PR TITLE
Migrate example projects to MMWormhole 2.0.0

### DIFF
--- a/example/xcode/WormholeExample/TodayObjC/TodayViewController.m
+++ b/example/xcode/WormholeExample/TodayObjC/TodayViewController.m
@@ -7,11 +7,11 @@
 
 #import "TodayViewController.h"
 #import <NotificationCenter/NotificationCenter.h>
-#import "MMWormholeClient.h"
+#import "MMWormhole.h"
 
 @interface TodayViewController () <NCWidgetProviding>
 
-@property (nonatomic, strong) MMWormholeClient *wormhole;
+@property (nonatomic, strong) MMWormhole *wormhole;
 @property (nonatomic, strong) NSNumber *displayCount;
 
 extern NSString * const SampleGroupIdentifier;
@@ -31,8 +31,9 @@ NSString * const SampleFieldName = @"displayNumber";
 - (void)viewDidLoad {
     [super viewDidLoad];
     self.preferredContentSize = CGSizeMake(320, 50);
-    self.wormhole = [[MMWormholeClient alloc] initWithApplicationGroupIdentifier:SampleGroupIdentifier
-                                                               optionalDirectory:SampleWormDirectory];
+    self.wormhole = [[MMWormhole alloc] initWithApplicationGroupIdentifier:SampleGroupIdentifier
+                                                         optionalDirectory:SampleWormDirectory];
+    
     [self initDisplayCounter:SampleEventName];
     [self addMessageListener:SampleEventName];
 }

--- a/example/xcode/WormholeExample/TodaySwift-Bridging-Header.h
+++ b/example/xcode/WormholeExample/TodaySwift-Bridging-Header.h
@@ -9,6 +9,6 @@
 #ifndef WormholeExample_WormholeExample_TodaySwift_Bridging_Header_h
 #define WormholeExample_WormholeExample_TodaySwift_Bridging_Header_h
 
-#import "MMWormholeClient.h"
+#import "MMWormhole.h"
 
 #endif

--- a/example/xcode/WormholeExample/TodaySwift/TodaySwift-Bridging-Header.h
+++ b/example/xcode/WormholeExample/TodaySwift/TodaySwift-Bridging-Header.h
@@ -8,6 +8,6 @@
 #ifndef WormholeExample_WormholeExample_TodaySwift_Bridging_Header_h
 #define WormholeExample_WormholeExample_TodaySwift_Bridging_Header_h
 
-#import "MMWormholeClient.h"
+#import "MMWormhole.h"
 
 #endif

--- a/example/xcode/WormholeExample/TodaySwift/TodayViewController.swift
+++ b/example/xcode/WormholeExample/TodaySwift/TodayViewController.swift
@@ -58,7 +58,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
     }
     
     func updateCounter() {
-        wormhole.passMessageObject([sampleFieldName : displayCount], identifier: sampleEventName)
+        wormhole.passMessageObject([sampleFieldName : displayCount] as NSCoding?, identifier: sampleEventName)
         displayCounter()
     }
     

--- a/example/xcode/WormholeExample/TodaySwift/TodayViewController.swift
+++ b/example/xcode/WormholeExample/TodaySwift/TodayViewController.swift
@@ -17,14 +17,14 @@ let sampleFieldName = "displayNumber";
 class TodayViewController: UIViewController, NCWidgetProviding {
  
     var displayCount = 0;
-    let wormhole = MMWormholeClient(applicationGroupIdentifier: sampleGroupIdentifier,
+    let wormhole = MMWormhole(applicationGroupIdentifier: sampleGroupIdentifier,
                                         optionalDirectory: sampleWormDirectory)
     
     @IBOutlet weak var countLabel: UILabel!
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.preferredContentSize = CGSizeMake(320, 50);
+        self.preferredContentSize = CGSize(width: 320, height: 50);
         addMessageListener(sampleEventName)
         initDisplayCounter(sampleEventName)
     }
@@ -33,28 +33,31 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         super.didReceiveMemoryWarning()
     }
     
-    func widgetPerformUpdateWithCompletionHandler(completionHandler: ((NCUpdateResult) -> Void)!) {
-        completionHandler(NCUpdateResult.NewData)
+    func widgetPerformUpdate(completionHandler: @escaping (NCUpdateResult) -> Void) {
+        completionHandler(NCUpdateResult.newData)
+        
     }
  
-    func addMessageListener(eventName : String){
-        self.wormhole.listenForMessageWithIdentifier(eventName, listener:{(messageObject:AnyObject!) -> Void in
-            if let fieldCount: AnyObject? = messageObject[sampleFieldName] {
-                self.displayCount = fieldCount as! Int!
+    func addMessageListener(_ eventName : String) {
+        self.wormhole.listenForMessage(withIdentifier: eventName, listener: { (messageObject) -> Void in
+            let message = messageObject as! Dictionary<String, Any>
+            if let fieldCount: AnyObject = message[sampleFieldName] as AnyObject? {
+                self.displayCount = fieldCount as! Int
                 self.displayCounter()
             }
         })
     }
     
-    func initDisplayCounter(eventName:String){
-        let savedMessage: AnyObject? = wormhole.messageWithIdentifier(eventName);
-         if let fieldCount: AnyObject?  = savedMessage?[sampleFieldName] {
+    func initDisplayCounter(_ eventName:String){
+        let savedMessage: Dictionary? = wormhole.message(withIdentifier:eventName) as! Dictionary<String, Any>?
+
+         if let fieldCount: Any?  = savedMessage?[sampleFieldName] as Any?? {
             self.displayCount = fieldCount as! Int!
             self.displayCounter()
         }
     }
     
-    func updateCounter(){
+    func updateCounter() {
         wormhole.passMessageObject([sampleFieldName : displayCount], identifier: sampleEventName)
         displayCounter()
     }
@@ -63,13 +66,13 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         self.countLabel.text = "Count:" + String(displayCount)
     }
     
-    @IBAction func addCountHandler(sender: UIButton) {
-        displayCount++;
+    @IBAction func addCountHandler(_ sender: UIButton) {
+        displayCount += 1;
         updateCounter()
     }
     
-    @IBAction func subtractCountHandler(sender: UIButton) {
-        displayCount--;
+    @IBAction func subtractCountHandler(_ sender: UIButton) {
+        displayCount -= 1;
         updateCounter()
     }
     

--- a/example/xcode/WormholeExample/WormholeExample.xcodeproj/project.pbxproj
+++ b/example/xcode/WormholeExample/WormholeExample.xcodeproj/project.pbxproj
@@ -13,8 +13,13 @@
 		CA83F57D1ACFA4A3003E81B2 /* NotificationCenter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA83F57C1ACFA4A3003E81B2 /* NotificationCenter.framework */; };
 		CA83F5831ACFA4A3003E81B2 /* TodayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CA83F5821ACFA4A3003E81B2 /* TodayViewController.m */; };
 		CA83F5851ACFA4A3003E81B2 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CA83F5841ACFA4A3003E81B2 /* MainInterface.storyboard */; };
-		CA90005C1AD0215500F98A33 /* MMWormholeClient.m in Sources */ = {isa = PBXBuildFile; fileRef = CA90005B1AD0215500F98A33 /* MMWormholeClient.m */; };
-		CA90005D1AD0215500F98A33 /* MMWormholeClient.m in Sources */ = {isa = PBXBuildFile; fileRef = CA90005B1AD0215500F98A33 /* MMWormholeClient.m */; };
+		DB6147001E379F0F0097BB10 /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F21E379F0E0097BB10 /* MMWormhole.m */; };
+		DB6147011E379F0F0097BB10 /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F41E379F0E0097BB10 /* MMWormholeCoordinatedFileTransiting.m */; };
+		DB6147021E379F0F0097BB10 /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F61E379F0E0097BB10 /* MMWormholeFileTransiting.m */; };
+		DB6147031E379F0F0097BB10 /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F81E379F0E0097BB10 /* MMWormholeSession.m */; };
+		DB6147041E379F0F0097BB10 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FA1E379F0E0097BB10 /* MMWormholeSessionContextTransiting.m */; };
+		DB6147051E379F0F0097BB10 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FC1E379F0E0097BB10 /* MMWormholeSessionFileTransiting.m */; };
+		DB6147061E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FE1E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,8 +36,21 @@
 		CA83F5821ACFA4A3003E81B2 /* TodayViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TodayViewController.m; sourceTree = "<group>"; };
 		CA83F5841ACFA4A3003E81B2 /* MainInterface.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
 		CA83F58C1ACFAD45003E81B2 /* TodayObjC.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = TodayObjC.entitlements; sourceTree = "<group>"; };
-		CA90005A1AD0215500F98A33 /* MMWormholeClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeClient.h; path = ../../../ClientSource/MMWormholeClient.h; sourceTree = "<group>"; };
-		CA90005B1AD0215500F98A33 /* MMWormholeClient.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeClient.m; path = ../../../ClientSource/MMWormholeClient.m; sourceTree = "<group>"; };
+		DB6146F11E379F0E0097BB10 /* MMWormhole.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormhole.h; path = ../../../iphone/Classes/MMWormhole.h; sourceTree = "<group>"; };
+		DB6146F21E379F0E0097BB10 /* MMWormhole.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormhole.m; path = ../../../iphone/Classes/MMWormhole.m; sourceTree = "<group>"; };
+		DB6146F31E379F0E0097BB10 /* MMWormholeCoordinatedFileTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeCoordinatedFileTransiting.h; path = ../../../iphone/Classes/MMWormholeCoordinatedFileTransiting.h; sourceTree = "<group>"; };
+		DB6146F41E379F0E0097BB10 /* MMWormholeCoordinatedFileTransiting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeCoordinatedFileTransiting.m; path = ../../../iphone/Classes/MMWormholeCoordinatedFileTransiting.m; sourceTree = "<group>"; };
+		DB6146F51E379F0E0097BB10 /* MMWormholeFileTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeFileTransiting.h; path = ../../../iphone/Classes/MMWormholeFileTransiting.h; sourceTree = "<group>"; };
+		DB6146F61E379F0E0097BB10 /* MMWormholeFileTransiting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeFileTransiting.m; path = ../../../iphone/Classes/MMWormholeFileTransiting.m; sourceTree = "<group>"; };
+		DB6146F71E379F0E0097BB10 /* MMWormholeSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeSession.h; path = ../../../iphone/Classes/MMWormholeSession.h; sourceTree = "<group>"; };
+		DB6146F81E379F0E0097BB10 /* MMWormholeSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeSession.m; path = ../../../iphone/Classes/MMWormholeSession.m; sourceTree = "<group>"; };
+		DB6146F91E379F0E0097BB10 /* MMWormholeSessionContextTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeSessionContextTransiting.h; path = ../../../iphone/Classes/MMWormholeSessionContextTransiting.h; sourceTree = "<group>"; };
+		DB6146FA1E379F0E0097BB10 /* MMWormholeSessionContextTransiting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeSessionContextTransiting.m; path = ../../../iphone/Classes/MMWormholeSessionContextTransiting.m; sourceTree = "<group>"; };
+		DB6146FB1E379F0E0097BB10 /* MMWormholeSessionFileTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeSessionFileTransiting.h; path = ../../../iphone/Classes/MMWormholeSessionFileTransiting.h; sourceTree = "<group>"; };
+		DB6146FC1E379F0E0097BB10 /* MMWormholeSessionFileTransiting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeSessionFileTransiting.m; path = ../../../iphone/Classes/MMWormholeSessionFileTransiting.m; sourceTree = "<group>"; };
+		DB6146FD1E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeSessionMessageTransiting.h; path = ../../../iphone/Classes/MMWormholeSessionMessageTransiting.h; sourceTree = "<group>"; };
+		DB6146FE1E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MMWormholeSessionMessageTransiting.m; path = ../../../iphone/Classes/MMWormholeSessionMessageTransiting.m; sourceTree = "<group>"; };
+		DB6146FF1E379F0F0097BB10 /* MMWormholeTransiting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MMWormholeTransiting.h; path = ../../../iphone/Classes/MMWormholeTransiting.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -78,8 +96,7 @@
 		CA83F56E1ACFA448003E81B2 = {
 			isa = PBXGroup;
 			children = (
-				CA90005A1AD0215500F98A33 /* MMWormholeClient.h */,
-				CA90005B1AD0215500F98A33 /* MMWormholeClient.m */,
+				DB6147071E379F150097BB10 /* MMWormhole */,
 				CA83F57E1ACFA4A3003E81B2 /* TodayObjC */,
 				CA2C5C5D1ACFEDC30063F646 /* TodaySwift */,
 				CA83F57B1ACFA4A3003E81B2 /* Frameworks */,
@@ -122,6 +139,28 @@
 				CA83F5801ACFA4A3003E81B2 /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		DB6147071E379F150097BB10 /* MMWormhole */ = {
+			isa = PBXGroup;
+			children = (
+				DB6146F11E379F0E0097BB10 /* MMWormhole.h */,
+				DB6146F21E379F0E0097BB10 /* MMWormhole.m */,
+				DB6146F31E379F0E0097BB10 /* MMWormholeCoordinatedFileTransiting.h */,
+				DB6146F41E379F0E0097BB10 /* MMWormholeCoordinatedFileTransiting.m */,
+				DB6146F51E379F0E0097BB10 /* MMWormholeFileTransiting.h */,
+				DB6146F61E379F0E0097BB10 /* MMWormholeFileTransiting.m */,
+				DB6146F71E379F0E0097BB10 /* MMWormholeSession.h */,
+				DB6146F81E379F0E0097BB10 /* MMWormholeSession.m */,
+				DB6146F91E379F0E0097BB10 /* MMWormholeSessionContextTransiting.h */,
+				DB6146FA1E379F0E0097BB10 /* MMWormholeSessionContextTransiting.m */,
+				DB6146FB1E379F0E0097BB10 /* MMWormholeSessionFileTransiting.h */,
+				DB6146FC1E379F0E0097BB10 /* MMWormholeSessionFileTransiting.m */,
+				DB6146FD1E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.h */,
+				DB6146FE1E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m */,
+				DB6146FF1E379F0F0097BB10 /* MMWormholeTransiting.h */,
+			);
+			name = MMWormhole;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -172,6 +211,7 @@
 					CA2C5C5A1ACFEDC20063F646 = {
 						CreatedOnToolsVersion = 6.2;
 						DevelopmentTeam = RCJGHLHMN9;
+						LastSwiftMigration = 0820;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
@@ -232,7 +272,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				CA2C5C611ACFEDC30063F646 /* TodayViewController.swift in Sources */,
-				CA90005D1AD0215500F98A33 /* MMWormholeClient.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -240,8 +279,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB6147041E379F0F0097BB10 /* MMWormholeSessionContextTransiting.m in Sources */,
 				CA83F5831ACFA4A3003E81B2 /* TodayViewController.m in Sources */,
-				CA90005C1AD0215500F98A33 /* MMWormholeClient.m in Sources */,
+				DB6147061E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m in Sources */,
+				DB6147021E379F0F0097BB10 /* MMWormholeFileTransiting.m in Sources */,
+				DB6147011E379F0F0097BB10 /* MMWormholeCoordinatedFileTransiting.m in Sources */,
+				DB6147001E379F0F0097BB10 /* MMWormhole.m in Sources */,
+				DB6147051E379F0F0097BB10 /* MMWormholeSessionFileTransiting.m in Sources */,
+				DB6147031E379F0F0097BB10 /* MMWormholeSession.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -296,6 +341,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "TodaySwift-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -339,6 +385,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "TodaySwift-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/example/xcode/WormholeExample/WormholeExample.xcodeproj/project.pbxproj
+++ b/example/xcode/WormholeExample/WormholeExample.xcodeproj/project.pbxproj
@@ -20,6 +20,13 @@
 		DB6147041E379F0F0097BB10 /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FA1E379F0E0097BB10 /* MMWormholeSessionContextTransiting.m */; };
 		DB6147051E379F0F0097BB10 /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FC1E379F0E0097BB10 /* MMWormholeSessionFileTransiting.m */; };
 		DB6147061E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FE1E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m */; };
+		DB6858B81E37A43C008A333C /* MMWormhole.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F21E379F0E0097BB10 /* MMWormhole.m */; };
+		DB6858BA1E37A43C008A333C /* MMWormholeCoordinatedFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F41E379F0E0097BB10 /* MMWormholeCoordinatedFileTransiting.m */; };
+		DB6858BC1E37A43C008A333C /* MMWormholeFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F61E379F0E0097BB10 /* MMWormholeFileTransiting.m */; };
+		DB6858BE1E37A43C008A333C /* MMWormholeSession.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146F81E379F0E0097BB10 /* MMWormholeSession.m */; };
+		DB6858C01E37A43C008A333C /* MMWormholeSessionContextTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FA1E379F0E0097BB10 /* MMWormholeSessionContextTransiting.m */; };
+		DB6858C21E37A43C008A333C /* MMWormholeSessionFileTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FC1E379F0E0097BB10 /* MMWormholeSessionFileTransiting.m */; };
+		DB6858C41E37A43C008A333C /* MMWormholeSessionMessageTransiting.m in Sources */ = {isa = PBXBuildFile; fileRef = DB6146FE1E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -220,7 +227,6 @@
 					};
 					CA83F5781ACFA4A3003E81B2 = {
 						CreatedOnToolsVersion = 6.2;
-						DevelopmentTeam = RCJGHLHMN9;
 						SystemCapabilities = {
 							com.apple.ApplicationGroups.iOS = {
 								enabled = 1;
@@ -271,6 +277,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB6858B81E37A43C008A333C /* MMWormhole.m in Sources */,
+				DB6858BA1E37A43C008A333C /* MMWormholeCoordinatedFileTransiting.m in Sources */,
+				DB6858BC1E37A43C008A333C /* MMWormholeFileTransiting.m in Sources */,
+				DB6858BE1E37A43C008A333C /* MMWormholeSession.m in Sources */,
+				DB6858C01E37A43C008A333C /* MMWormholeSessionContextTransiting.m in Sources */,
+				DB6858C21E37A43C008A333C /* MMWormholeSessionFileTransiting.m in Sources */,
+				DB6858C41E37A43C008A333C /* MMWormholeSessionMessageTransiting.m in Sources */,
 				CA2C5C611ACFEDC30063F646 /* TodayViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -279,14 +292,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DB6147001E379F0F0097BB10 /* MMWormhole.m in Sources */,
 				DB6147041E379F0F0097BB10 /* MMWormholeSessionContextTransiting.m in Sources */,
-				CA83F5831ACFA4A3003E81B2 /* TodayViewController.m in Sources */,
 				DB6147061E379F0F0097BB10 /* MMWormholeSessionMessageTransiting.m in Sources */,
 				DB6147021E379F0F0097BB10 /* MMWormholeFileTransiting.m in Sources */,
 				DB6147011E379F0F0097BB10 /* MMWormholeCoordinatedFileTransiting.m in Sources */,
-				DB6147001E379F0F0097BB10 /* MMWormhole.m in Sources */,
 				DB6147051E379F0F0097BB10 /* MMWormholeSessionFileTransiting.m in Sources */,
 				DB6147031E379F0F0097BB10 /* MMWormholeSession.m in Sources */,
+				CA83F5831ACFA4A3003E81B2 /* TodayViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -424,6 +437,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -472,6 +486,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;


### PR DESCRIPTION
Updated the Obj-C and Swift projects to use the 2.0.0 library of `MMWormhole`. There is one outstanding error in the Swift example that I was able to resolve so far:
```swift
wormhole.passMessageObject([sampleFieldName : displayCount], identifier: sampleEventName)
```
Error:
```
TodayViewController.swift:61:36: Contextual type 'NSCoding' cannot be used with dictionary literal
```

**EDIT**: Fixed in second commit. 